### PR TITLE
Add a member use_odirect_ to DirectFile to support upper level applications

### DIFF
--- a/include/rosbag_direct_write/direct_bag.h
+++ b/include/rosbag_direct_write/direct_bag.h
@@ -81,7 +81,7 @@ private:
   int file_descriptor_;
 #endif
   bool open_;
-
+  bool use_odirect_;
 };
 
 /// The DirectBag class provides an interface for writing ROS messages or
@@ -312,7 +312,6 @@ private:
   bool use_odirect_;
 
   std::atomic<bool> open_;
-  bool use_odirect_;
   size_t current_bag_number_;
   shared_ptr<DirectBag> current_bag_;
 };

--- a/include/rosbag_direct_write/direct_bag.h
+++ b/include/rosbag_direct_write/direct_bag.h
@@ -312,6 +312,7 @@ private:
   bool use_odirect_;
 
   std::atomic<bool> open_;
+  bool use_odirect_;
   size_t current_bag_number_;
   shared_ptr<DirectBag> current_bag_;
 };

--- a/src/direct_bag.cpp
+++ b/src/direct_bag.cpp
@@ -211,7 +211,7 @@ size_t DirectBag::get_virtual_bag_size() const {
 }
 
 DirectFile::DirectFile(std::string filename, bool use_odirect)
-    : filename_(filename), open_(true) {
+    : filename_(filename), open_(true), use_odirect_(use_odirect) {
 #ifdef __APPLE__
   file_pointer_ = fopen(filename.c_str(), "w+b");
   if (file_pointer_ == nullptr) {
@@ -320,9 +320,11 @@ uint8_t* AllocateAlignedBuffer(size_t buffer_size_bytes) {
 
 size_t DirectFile::write_data(const uint8_t* start, size_t length) {
   size_t current_offset = get_offset();
-  assert((current_offset % 4096) == 0);
-  assert((reinterpret_cast<uintptr_t>(start) % 4096) == 0);
-  assert((length % 4096) == 0);
+  if (use_odirect_) {
+    assert((current_offset % 4096) == 0);
+    assert((reinterpret_cast<uintptr_t>(start) % 4096) == 0);
+    assert((length % 4096) == 0);
+  }
 #if __APPLE__
   ssize_t ret = fwrite(start, sizeof(uint8_t), length, file_pointer_);
   if (ret < 0) {


### PR DESCRIPTION
This PR adds a member use_odirect_ to the DirectFile class so we have an option to turn off O_DIRECT on platforms that do not support it.