### PR TITLE
Adding INCLUDE and LIBRARIES to catkin_package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,11 @@ project(rosbag_direct_write)
 
 find_package(catkin REQUIRED COMPONENTS cpp_common rosbag_storage)
 
-catkin_package(CATKIN_DEPENDS cpp_common rosbag_storage)
+catkin_package(
+	INCLUDE_DIRS include
+	CATKIN_DEPENDS cpp_common rosbag_storage
+	LIBRARIES rosbag_direct_write
+)
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 


### PR DESCRIPTION
Adding INCLUDE and LIBRARIES to CMakeLists.txt for the project to be correctly used from other rosbag packages.